### PR TITLE
Package CRIS for opam installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 COQMODULE    := CRIS
+ROCQ         ?= rocq
 COQTHEORIES  := $(shell find . -not -path "./deprecated/*" -not -path "./_opam/*" -iname '*.v')
 COQEXTRACT  := extract/ExtrOcamlCRIS.v
 COQDIRS      := $(shell find itreeS library theories -type d | sort)
@@ -46,7 +47,7 @@ Makefile.coq: Makefile $(COQTHEORIES) $(extract_files)
 	 echo "-Q itreeS ITreeS"; \
 	 echo "-Q extract $(COQMODULE)"; \
 	 echo $(COQTHEORIES)) > _CoqProject
-	coq_makefile -f _CoqProject -o Makefile.coq
+	$(ROCQ) makefile -f _CoqProject -o Makefile.coq
 
 clean: Makefile.coq
 	$(MAKE) -f Makefile.coq clean || true

--- a/rocq-cris.opam
+++ b/rocq-cris.opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+name: "rocq-cris"
+version: "dev"
+
+synopsis: "Contextual Refinement with Imaginary Specifications"
+description: """
+CRIS is a Rocq framework for reasoning about contextual refinement with
+imaginary specifications, interaction trees, and simulation relations.
+"""
+
+maintainer: "SNU Software Foundations Lab"
+authors: "SNU Software Foundations Lab"
+license: "Apache-2.0"
+
+homepage: "https://github.com/snu-sf/CRIS"
+bug-reports: "https://github.com/snu-sf/CRIS/issues"
+dev-repo: "git+https://github.com/snu-sf/CRIS.git"
+
+depends: [
+  "coq" {= "9.0.0"}
+  "coq-paco" {= "4.2.3"}
+  "coq-itree" {= "5.2.1"}
+  "coq-ext-lib" {= "0.13.0"}
+  "coq-ordinal" {= "0.5.6"}
+  "coq-stdpp" {= "1.12.0"}
+  "coq-iris" {= "4.4.0"}
+]
+
+build: [make "-j%{jobs}%"]
+install: [make "-f" "Makefile.coq" "install"]


### PR DESCRIPTION
## Summary

- Add the `rocq-cris` opam package definition for Rocq 9.0.0.
- Generate `Makefile.coq` through the Rocq 9 `rocq makefile` command.
- Keep CRIS definitions, semantics, and proofs unchanged.

## Validation

- `opam lint rocq-cris.opam`
- Clean package build and installation with two jobs
- Reinstallation from the exact public commit
- External imports of `CRIS`, `Atomic`, and `ITreeS` from the installed package