### PR TITLE
introduce internal behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ release.
 - rename: `closed_adequacy` -> `ISim_closed_adequacy`
 - add `gsim_closed_adequacy`, `lsim_closed_adequacy`
 - move `theories/simulations/filter` to `theories/filter`
+- Add `Beh : Mod.t -> Tr.t -> iProp Σ`
+- Redefine `refines` using `Beh`. This new definition is equivalent to the old one.
 
 ## 2026-07-22
 

--- a/library/prophecy/ProphecyIAproof.v
+++ b/library/prophecy/ProphecyIAproof.v
@@ -1627,22 +1627,36 @@ Module ProphIA. Section ProphIA.
     ProphecyA.initial_cond ⊢
       refines (md ★ ProphecyI.t mn) (md ★ ProphecyA.t mn sp).
   Proof using Hreal.
-    eapply entails_pointwise. intros r _ Hr.
-    iApply Own_general_completeness.
-    rewrite refines_unseal.
-    intros WFMODT. split; [apply src_mod_wf; et|].
-    intros rt rs SPLIT VALID.
     assert (PROPH :
-      Own r ⊢
+      ProphecyA.initial_cond ⊢
         Own (own.iRes_singleton proph_name
           (proph_auth_r (Ensembles.Full_set Prophecy.ID)
             (λ _ : Prophecy.ID, dummy_prophinst)))).
-    { rewrite Hr /ProphecyA.initial_cond /proph_auth.
+    { rewrite /ProphecyA.initial_cond /proph_auth.
       rewrite own.own_eq /own.own_def own.Own_eq //. }
-    eapply adequacy_refines_mod; et.
-    eapply Own_bupd_update.
-    iIntros "S". iDestruct (SPLIT with "S") as "[T [R _]]".
-    iModIntro. rewrite Own_op. iFrame "T".
-    iApply PROPH. done.
+    iIntros "INIT %WFMODT".
+    iSplit. { iPureIntro. apply src_mod_wf; et. }
+    iIntros "WINV %t TGT".
+    iRevert "TGT INIT WINV"; iIntros "TGT INIT WINV". iStopProof.
+    eapply entails_pointwise. intros rs Vrs Hrs.
+    eapply Own_split' in Hrs; et.
+    destruct Hrs as [rt [Vrt [Hrt Hrs]]].
+    eapply Own_general_completeness. rewrite Beh_unseal.
+    intros rs' Vrs' LE.
+    assert (REF :
+      refines_lmod
+        (Mod.to_lmod (md ★ ProphecyI.t mn) rt)
+        (Mod.to_lmod (md ★ ProphecyA.t mn sp) rs')).
+    { eapply adequacy_refines_mod; et.
+      eapply Own_bupd_update.
+      iIntros "S".
+      iPoseProof (Own_extends with "S") as "S"; et.
+      iDestruct (Hrs with "S") as "[T [INIT _]]".
+      iModIntro. rewrite Own_op. iFrame "T".
+      iApply PROPH. done.
+    }
+    eapply REF.
+    eapply Own_general_soundness in Hrt; et.
+    rewrite Beh_unseal in Hrt. eapply Hrt; et.
   Qed.
 End ProphIA. End ProphIA.

--- a/theories/simulations/ctxrefine/BehFacts.v
+++ b/theories/simulations/ctxrefine/BehFacts.v
@@ -1,0 +1,44 @@
+From CRIS.common Require Import Common ConcRA.
+From CRIS.modules Require Import Mod LMod.
+From CRIS.simulations.gsim Require Import GSimAdequacy.
+From CRIS.simulations.lsim Require Import LSimAdequacy.
+From CRIS.simulations.msim Require Import MSimCommon ISimFacts ISimAdequacy.
+From CRIS.simulations.ctxrefine Require Import CtxRefine.
+
+Section MOD_BEHAVIOR.
+
+  Context `{!crisG Γ Σ α β τ _S _I}.
+
+  Lemma Beh_intro
+    M t r
+    (WF : Mod.wf M)
+    (BEH : Beh.of_itree (LMod.compile (Mod.to_lmod M r) tt↑) t)
+    : Own r ∗ winv (∅,∅) ⊢ Beh M t.
+  Proof.
+    eapply entails_pointwise. intros rt Vrt Hrt.
+    eapply Own_general_completeness. rewrite Beh_unseal.
+    intros rt' Vrt' LE.
+    assert (REFL : ISim.ISim.t closed M M emp IstEq).
+    { eapply ISim_refl; et. }
+    eapply (ISim_adequacy _ _ rt' r) in REFL; et.
+    2:{
+      iIntros "H". iModIntro.
+      iPoseProof (Own_extends with "H") as "H"; et.
+      iDestruct (Hrt with "H") as "[$ $]".
+    }
+    eapply (lsim_adequacy _ _ (tt↑)) in REFL.
+    eapply gsim_adequacy with (x0 := t) in REFL; et.
+  Qed.
+
+  Lemma Beh_elim
+    M t r
+    (BEH : Own r ⊢ Beh M t)
+    : forall r', ✓ r' -> r ≼ r' -> Beh.of_itree (LMod.compile (Mod.to_lmod M r) tt↑) t.
+  Proof.
+    intros r' Vr' LE.
+    assert (Vr : ✓ r) by (eapply cmra_valid_included; et).
+    eapply Own_general_soundness in BEH; et.
+    rewrite Beh_unseal in BEH. eapply BEH; et.
+  Qed.
+
+End MOD_BEHAVIOR.

--- a/theories/simulations/ctxrefine/ClosedAdequacy.v
+++ b/theories/simulations/ctxrefine/ClosedAdequacy.v
@@ -10,6 +10,19 @@ From CRIS.simulations.ctxrefine Require Import CtxRefine.
 Section ADEQUACY.
   Context `{!crisG Γ Σ α β τ _S _I}.
 
+  Lemma Own_split'
+    r P Q
+    (Vr : ✓ r)
+    (H : Own r ⊢ P ∗ Q)
+    : ∃ x, ✓ x /\ (Own x ⊢ P) /\ (Own r ⊢ Own x ∗ Q).
+  Proof.
+    eapply Own_split in H; et. destruct H as [a [b [E [H1 H2]]]].
+    exists a. splits.
+    - eapply cmra_valid_op_l. rewrite <- E; et.
+    - et.
+    - rewrite E. rewrite Own_op. rewrite H2. et.
+  Qed.
+
   Theorem gsim_closed_adequacy
     (Mt Ms : Mod.t) (IC : iProp Σ)
     (SIM : Mod.wf Mt ->
@@ -23,12 +36,24 @@ Section ADEQUACY.
                  (LMod.LMod.compile (Mod.to_lmod Mt rt) () ↑))
     : IC ⊢ refines Mt Ms.
   Proof.
-    eapply entails_pointwise. intros x Vx Hx.
-    eapply Own_general_completeness. rewrite refines_unseal.
-    intros WFT. specialize (SIM WFT). destruct SIM as [WFS SIM].
-    split; et. intros rt rs Hrs Vrs.
-    unfold refines_lmod. eapply gsim_adequacy.
-    eapply SIM; et. rewrite Hrs Hx; et.
+    iIntros "IC %WFT".
+    specialize (SIM WFT). destruct SIM as [WFS SIM].
+    iSplit. { iPureIntro. et. }
+    iIntros "WINV %t TGT".
+    iRevert "TGT IC WINV"; iIntros "TGT IC WINV". iStopProof.
+    eapply entails_pointwise. intros rs Vrs Hrs.
+    eapply Own_split' in Hrs; et. destruct Hrs as [rt [Vrt [Hrt Hrs]]].
+    eapply Own_general_completeness. rewrite Beh_unseal.
+    intros rs' Vrs' LE.
+    assert (SPLIT : Own rs' ⊢ Own rt ∗ IC ∗ winv (∅,∅)).
+    { iIntros "H". iApply Hrs. iApply Own_extends; et. }
+    specialize (SIM rt rs' Vrs' SPLIT).
+    eapply gsim_adequacy with (x0 := t) in SIM.
+    2:{
+      eapply Own_general_soundness in Hrt; et.
+      rewrite Beh_unseal in Hrt. eapply Hrt; et.
+    }
+    eapply SIM.
   Qed.
 
   Theorem lsim_closed_adequacy

--- a/theories/simulations/ctxrefine/CtxRefine.v
+++ b/theories/simulations/ctxrefine/CtxRefine.v
@@ -8,30 +8,31 @@ Definition refines_lmod (ms_tgt ms_src: LMod.t) : Prop :=
   Beh.of_itree (LMod.compile ms_tgt tt↑) <1=
   Beh.of_itree (LMod.compile ms_src tt↑).
 
+Section MOD_BEHAVIOR.
+
+  Context `{!crisG Γ Σ α β τ _S _I}.
+
+  Program Definition Beh_def (M : Mod.t) (t : Tr.t) : iProp Σ :=
+    {| uPred_holds :=
+        fun r => forall r', ✓ r' ->
+                    r ≼ r' ->
+                    Beh.of_itree (LMod.compile (Mod.to_lmod M r') tt↑) t
+    |}.
+  Next Obligation.
+    intros ???? H ????. eapply H; et. etrans; et.
+  Qed.
+  Definition Beh_aux : seal (@Beh_def). Proof. by eexists. Qed.
+  Definition Beh := Beh_aux.(unseal).
+  Definition Beh_unseal : @Beh = @Beh_def := Beh_aux.(seal_eq).
+
+End MOD_BEHAVIOR.
+
 Section REFINEMENT.
 
   Context `{!crisG Γ Σ α β τ _S _I}.
 
-  Program Definition refines_def (Mt Ms : Mod.t) : iProp Σ :=
-    {| uPred_holds :=
-        fun r =>
-          Mod.wf Mt ->
-          Mod.wf Ms /\
-            forall rt rs,
-              (Own rs ⊢ Own rt ∗ Own r ∗ winv (∅,∅)) ->
-              ✓ rs -> refines_lmod (Mod.to_lmod Mt rt) (Mod.to_lmod Ms rs)
-    |}.
-  Next Obligation.
-    intros Mt Ms x1 x2 M_LE x_LE WFT.
-    specialize (M_LE WFT). destruct M_LE as [WFS M_LE]. split; et.
-    intros rt rs SPLIT V. eapply M_LE; et.
-    iIntros "H".
-    iPoseProof (SPLIT with "H") as "($ & H & $)".
-    iApply Own_extends; et.
-  Qed.
-  Definition refines_aux : seal (@refines_def). Proof. by eexists. Qed.
-  Definition refines := refines_aux.(unseal).
-  Definition refines_unseal : @refines = @refines_def := refines_aux.(seal_eq).
+  Definition refines (Mt Ms : Mod.t) : iProp Σ :=
+      ⌜ Mod.wf Mt ⌝ → ⌜ Mod.wf Ms ⌝ ∧ (winv (∅,∅) -∗ ∀ t, Beh Mt t -∗ Beh Ms t).
 
   Definition ctx_refines (Mt Ms : Mod.t) : iProp Σ :=
     ∀ (Ctx : Mod.t), refines (Mt ★ Ctx) (Ms ★ Ctx).

--- a/theories/simulations/ctxrefine/CtxRefineFacts.v
+++ b/theories/simulations/ctxrefine/CtxRefineFacts.v
@@ -1,7 +1,7 @@
 From iris.proofmode Require Import proofmode.
 From CRIS.common Require Import Common ConcRA.
 From CRIS.modules Require Import Mod.
-From CRIS.simulations.ctxrefine Require Import CtxRefine ClosedAdequacy MainAdequacy.
+From CRIS.simulations.ctxrefine Require Import CtxRefine ClosedAdequacy MainAdequacy BehFacts.
 From CRIS.simulations.msim Require Import Tactics TacticsInit MSimCommon ISimFacts.
 
 (** Properties of contextual refinement *)
@@ -14,47 +14,20 @@ Section CtxRefineFacts.
 
   Lemma refines_refl M : ⊢ refines M M.
   Proof.
-    iStartProof.
-    iApply (ISim_closed_adequacy _ _ True%I IstEq); et.
-    eapply ISim_refl; et.
+    iIntros "%WFT". iSplit; et.
   Qed.
 
   Lemma refines_trans M1 M2 M3 :
     refines M1 M2 ∗ refines M2 M3 ⊢ refines M1 M3.
   Proof.
-    econs. intros x V_x. uPred.unseal.
-    intros [r1 [r2 [SPLIT [H1 H2]]]]. revert H1 H2.
-    intros R1 R2.
-    rewrite refines_unseal; intros WF1.
-    rewrite refines_unseal in R1; specialize (R1 WF1). destruct R1 as [WF2 R1].
-    rewrite refines_unseal in R2; specialize (R2 WF2). destruct R2 as [WF3 R2].
-    split. { eapply WF3. }
-    intros rt rs H0 V_rs.
-    assert (H1: Own rs ⊢ (Own rt ∗ Own r1 ∗ winv (∅,∅)) ∗ Own r2 ∗ winv (∅,∅)).
-    { iIntros "H". iDestruct (H0 with "H") as "(H1 & H2 & H3)".
-      rewrite SPLIT. iDestruct (Own_op with "H2") as "[H21 H22]".
-      iDestruct (winv_split_empty with "H3") as "[H31 H32]".
-      iFrame.
-    }
-    assert (H2: exists rs1, (Own rs1 ⊢ Own rt ∗ Own r1 ∗ winv (∅,∅)) /\ ✓ rs1
-                       /\ (Own rs ⊢ Own rs1 ∗ Own r2 ∗ winv (∅,∅))).
-    { clear - H1 V_rs.
-      remember (Own rt ∗ Own r1 ∗ winv (∅,∅))%I as P.
-      remember (Own r2 ∗ winv (∅,∅))%I as Q.
-      eapply Own_general_soundness in H1; et.
-      uPred.unseal_in H1. destruct H1 as [rs1 [rs2 [SPLIT [H1 H2]]]].
-      exists rs1. splits.
-      - eapply Own_general_completeness; et.
-      - rewrite SPLIT in V_rs.
-        eapply cmra_valid_op_l in V_rs.
-        et.
-      - rewrite SPLIT. iIntros "[$ H]". iStopProof.
-        eapply Own_general_completeness; et.
-    }
-    destruct H2 as [rs1 [H_rs1 [V_rs1 H_rs]]].
-    specialize (R1 rt rs1 H_rs1 V_rs1).
-    specialize (R2 rs1 rs H_rs V_rs).
-    clear - R1 R2. intros t H. eapply R2. eapply R1. et.
+    iIntros "[H1 H2] %WF1".
+    iDestruct ("H1" $! WF1) as "[%WF2 H1]".
+    iDestruct ("H2" $! WF2) as "[%WF3 H2]".
+    iSplit; et. iIntros "WINV %t BEH1".
+    iDestruct (winv_split_empty with "WINV") as "[WINV1 WINV2]".
+    iApply ("H2" with "WINV2").
+    iApply ("H1" with "WINV1").
+    et.
   Qed.
 
   (*** vertical composition ***)
@@ -178,15 +151,24 @@ Section ADEQUACY.
     : winv (∅,∅) ∗ refines Mt Ms
         ⊢ ⌜ ∃ rs, ✓ rs /\ refines_lmod (Mod.to_lmod Mt ε) (Mod.to_lmod Ms rs) ⌝.
   Proof.
-    eapply entails_pointwise. intros r Vr Hr.
-    eapply Own_general_soundness in Hr; et.
-    uPred.unseal_in Hr. destruct Hr as [r1 [r2 [SPLIT [WINV REF]]]].
-    eapply Own_general_completeness in WINV.
-    rewrite refines_unseal in REF. specialize (REF WF). destruct REF as [WFS REF].
-    specialize (REF ε r).
-    eapply Own_general_completeness. uPred.unseal. exists r. split; et.
-    eapply REF; et. rewrite SPLIT.
-    iIntros "[H1 H2]". rewrite WINV. iFrame. iApply Own_unit.
+    eapply entails_pointwise. intros rs Vrs Hrs.
+    iIntros "_". iPureIntro. exists rs. split; et.
+    intros t TGT.
+    assert (winv (∅,∅) ⊢ Beh Mt t).
+    { iIntros "WINV".
+      iApply Beh_intro; et.
+      iFrame. iApply Own_unit.
+    }
+    assert (SRC : Own rs ⊢ Beh Ms t).
+    { rewrite Hrs.
+      iIntros "[WINV REF]".
+      iDestruct (winv_split_empty with "WINV") as "[WINV1 WINV2]".
+      iDestruct ("REF" $! WF) as "[_ REF]".
+      iApply ("REF" with "WINV1").
+      iApply H; et.
+    }
+    clear - SRC Vrs.
+    eapply Beh_elim in SRC; et.
   Qed.
 
 End ADEQUACY.


### PR DESCRIPTION
Introduce `Beh : Mod.t -> Tr.t -> iProp Σ`.

`Beh` enables natural definition of refinement
```
  Definition refines (Mt Ms : Mod.t) : iProp Σ :=
      ⌜ Mod.wf Mt ⌝ → ⌜ Mod.wf Ms ⌝ ∧ (winv (∅,∅) -∗ ∀ t, Beh Mt t -∗ Beh Ms t).
```

This new definition of `refines` relation is equivalent to the existing definition.