### PR TITLE
sim: prevent reduction loops in function lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 - change extraction setting of `SchI.choose_index` in `ExtrOcamlCRIS.v`
 - optimize function lookup and post-inline normalization in `cStartFunSim`
   and `cInlineS`/`cInlineT`
+- make certificate-based function lookup expose module aliases structurally
+  and fail fast on unsupported map combinators before the `simpl_map`
+  fallback; custom lookup instances must also be registered in the
+  `fnsem_lookup` hint database
 - replace Helping's client-visible request state with a resource-only
   `HelpPend`/`HelpDone` protocol and make `HelpingOn.try_run` request-ID-only
 - add nested `IstHelp` transport and `helping_main_filtered` for client

--- a/theories/filter/CallFilter.v
+++ b/theories/filter/CallFilter.v
@@ -598,6 +598,8 @@ Module CFilter. Section CFilter.
   
 End CFilter. End CFilter.
 
+Global Hint Resolve CFilter.fnsem_lookup_result_filter | 20 : fnsem_lookup.
+
 Ltac cfilter_solver :=
   let X := fresh "X" in let e := fresh "e" in
   apply Mod.t_eq; ss;

--- a/theories/simulations/msim/FnsemLookup.v
+++ b/theories/simulations/msim/FnsemLookup.v
@@ -1,6 +1,14 @@
 From CRIS.common Require Import Common ConcRA.
 From CRIS.modules Require Import Mod SMod.
 
+Create HintDb fnsem_lookup discriminated.
+(** [rewrite_fnsem_lookup] searches only this database. Lookup extensions
+    should register their instances here so unsupported heads remain opaque. *)
+Global Hint Variables Opaque : fnsem_lookup.
+Global Hint Constants Opaque : fnsem_lookup.
+Global Hint Projections Opaque : fnsem_lookup.
+Global Hint Transparent Mod.fnsems SMod.fnsems : fnsem_lookup.
+
 (** Keep concrete leaf-map search separate from composed module search so that
     wrapper instances do not compete at every insert. *)
 Class MapLookupResult
@@ -9,6 +17,7 @@ Class MapLookupResult
   { map_lookup_result_eq : m !! k = result }.
 
 Global Hint Mode MapLookupResult + + + + + + - : typeclass_instances.
+Global Hint Mode MapLookupResult + + + + + + - : fnsem_lookup.
 
 Global Instance map_lookup_result_empty
   {K A} `{Countable K}
@@ -39,6 +48,7 @@ Class FnsemLookupResult {A}
   { fnsem_lookup_result_eq : m !! fn = result }.
 
 Global Hint Mode FnsemLookupResult + + + - : typeclass_instances.
+Global Hint Mode FnsemLookupResult + + + - : fnsem_lookup.
 
 Global Instance fnsem_lookup_result_add `{Σ : GRA}
     (left right : @Mod.t Σ) fn left_result right_result
@@ -63,3 +73,9 @@ Proof.
   constructor. rewrite /SMod.to_mod /Mod.fnsems /= lookup_fmap
     map_lookup_result_eq //.
 Qed.
+
+Global Hint Resolve map_lookup_result_empty : fnsem_lookup.
+Global Hint Resolve map_lookup_result_insert_hit | 5 : fnsem_lookup.
+Global Hint Resolve map_lookup_result_insert | 10 : fnsem_lookup.
+Global Hint Resolve fnsem_lookup_result_add | 10 : fnsem_lookup.
+Global Hint Resolve fnsem_lookup_result_to_mod | 30 : fnsem_lookup.

--- a/theories/simulations/msim/ISim.v
+++ b/theories/simulations/msim/ISim.v
@@ -846,6 +846,7 @@ Proof.
   constructor. rewrite /sandbox_fnsemmap lookup_fmap
     fnsem_lookup_result_eq //.
 Qed.
+Global Hint Resolve fnsem_lookup_result_sandbox : fnsem_lookup.
 Global Hint Extern 80 (sandbox_fnsemmap _ !! _ = Some _) =>
   rewrite /sandbox_fnsemmap; simpl_map : simpl_map.
 

--- a/theories/simulations/msim/TacticsCommon.v
+++ b/theories/simulations/msim/TacticsCommon.v
@@ -530,10 +530,160 @@ Ltac prove_sub_perm :=
   end);
   apply sub_perm_nil.
 
+Ltac fnsem_lookup_outer_head t :=
+  lazymatch t with
+  | ?f _ => fnsem_lookup_outer_head f
+  | _ => t
+  end.
+
+Ltac fnsem_lookup_replace_outer_head t body :=
+  lazymatch t with
+  | ?f ?x =>
+      let f' := fnsem_lookup_replace_outer_head f body in
+      constr:(f' x)
+  | _ => constr:(body)
+  end.
+
+(** Unfold exactly the outer constant. Rebuilding its application separately
+    keeps fix/iota reduction out of the alias-exposure phase. *)
+Ltac fnsem_lookup_delta_outer_once t :=
+  let h := fnsem_lookup_outer_head t in
+  let body := eval unfold h in h in
+  let raw := fnsem_lookup_replace_outer_head t body in
+  let t' := eval cbv beta zeta in raw in
+  constr:(t').
+
+(** Commit one delta attempt inside a closed term, leaving no Ltac
+    backtracking choice when the later typeclass search fails. *)
+Ltac fnsem_lookup_delta_outer_once_opt t :=
+  let T := type of t in
+  constr:((ltac:(first
+    [ let t' := fnsem_lookup_delta_outer_once t in exact (Some t')
+    | exact None
+    ])) : option T).
+
+Ltac fnsem_lookup_has_module_arg t :=
+  lazymatch t with
+  | ?f ?x =>
+      let T := type of x in
+      lazymatch T with
+      | @Mod.t _ => constr:(true)
+      | @SMod.t _ => constr:(true)
+      | _ => fnsem_lookup_has_module_arg f
+      end
+  | _ => constr:(false)
+  end.
+
+Ltac fnsem_lookup_has_map_arg t :=
+  lazymatch t with
+  | ?f ?x =>
+      let T := type of x in
+      lazymatch T with
+      | gmap _ _ => constr:(true)
+      | _ => fnsem_lookup_has_map_arg f
+      end
+  | _ => constr:(false)
+  end.
+
+Ltac fnsem_lookup_normalize_module_args t :=
+  lazymatch t with
+  | ?f ?x =>
+      let f' := fnsem_lookup_normalize_module_args f in
+      let T := type of x in
+      lazymatch T with
+      | @Mod.t _ =>
+          let x' := fnsem_lookup_normalize_module x in
+          constr:(f' x')
+      | @SMod.t _ =>
+          let x' := fnsem_lookup_normalize_module x in
+          constr:(f' x')
+      | _ => constr:(f' x)
+      end
+  | _ => constr:(t)
+  end
+with fnsem_lookup_normalize_map_args t :=
+  lazymatch t with
+  | ?f ?x =>
+      let f' := fnsem_lookup_normalize_map_args f in
+      let T := type of x in
+      lazymatch T with
+      | gmap _ (option (emask * fbody)) =>
+          let x' := fnsem_lookup_normalize_map x in
+          constr:(f' x')
+      | gmap _ (option (emask * (option fspec_rel * fbody))) =>
+          let x' := fnsem_lookup_normalize_map x in
+          constr:(f' x')
+      | _ => constr:(f' x)
+      end
+  | _ => constr:(t)
+  end
+with fnsem_lookup_normalize_module m :=
+  lazymatch m with
+  | @Mod.mk ?Σ ?scopes ?fns ?initial ?sorted ?wfns ?winit ?nodup =>
+      let fns' := fnsem_lookup_normalize_map fns in
+      constr:(@Mod.mk Σ scopes fns' initial sorted wfns winit nodup)
+  | @SMod.mk ?Σ ?scopes ?fns ?initial ?sorted ?wfns ?winit ?nodup =>
+      let fns' := fnsem_lookup_normalize_map fns in
+      constr:(@SMod.mk Σ scopes fns' initial sorted wfns winit nodup)
+  | _ =>
+      let delta := fnsem_lookup_delta_outer_once_opt m in
+      lazymatch delta with
+      | Some ?m' =>
+          lazymatch m' with
+          | @Mod.mk _ _ _ _ _ _ _ _ =>
+              let has_arg := fnsem_lookup_has_module_arg m in
+              lazymatch has_arg with
+              | true => fnsem_lookup_normalize_module_args m
+              | false => fnsem_lookup_normalize_module m'
+              end
+          | @SMod.mk _ _ _ _ _ _ _ _ =>
+              let has_arg := fnsem_lookup_has_module_arg m in
+              lazymatch has_arg with
+              | true => fnsem_lookup_normalize_module_args m
+              | false => fnsem_lookup_normalize_module m'
+              end
+          | _ => fnsem_lookup_normalize_module m'
+          end
+      | None => constr:(m)
+      end
+  end
+with fnsem_lookup_normalize_map m :=
+  lazymatch m with
+  | Mod.fnsems ?md =>
+      let md' := fnsem_lookup_normalize_module md in
+      lazymatch md' with
+      | @Mod.mk _ _ ?fns _ _ _ _ _ => fnsem_lookup_normalize_map fns
+      | _ => constr:(Mod.fnsems md')
+      end
+  | SMod.fnsems ?md =>
+      let md' := fnsem_lookup_normalize_module md in
+      lazymatch md' with
+      | @SMod.mk _ _ ?fns _ _ _ _ _ => fnsem_lookup_normalize_map fns
+      | _ => constr:(SMod.fnsems md')
+      end
+  | @base.empty _ _ => constr:(m)
+  | _ =>
+      let has_arg := fnsem_lookup_has_map_arg m in
+      lazymatch has_arg with
+      | true => fnsem_lookup_normalize_map_args m
+      | false =>
+          let delta := fnsem_lookup_delta_outer_once_opt m in
+          lazymatch delta with
+          | Some ?m' => fnsem_lookup_normalize_map m'
+          | None => constr:(m)
+          end
+      end
+  end.
+
 Ltac rewrite_fnsem_lookup fl fn :=
   let Hlookup := fresh "Hlookup" in
-  assert (Hlookup : FnsemLookupResult fl fn _) by
-    solve [once (typeclasses eauto)];
+  first
+    [ assert (Hlookup : FnsemLookupResult fl fn _) by
+        solve [once (typeclasses eauto with fnsem_lookup)]
+    | let fl' := fnsem_lookup_normalize_map fl in
+      assert (Hlookup : FnsemLookupResult fl' fn _) by
+        solve [once (typeclasses eauto with fnsem_lookup)]
+    ];
   destruct Hlookup as [Hlookup];
   rewrite {1}Hlookup; clear Hlookup.
 


### PR DESCRIPTION
## Summary

- try certificate lookup on the original map before structural normalization, preserving raw-shape custom instances
- structurally expose module and function-map aliases for a second lookup attempt
- isolate lookup certificates in an opaque fnsem_lookup hint database so unsupported map combinators fail quickly into the existing simpl_map fallback
- document the custom hint-database extension contract in the changelog

## Motivation

For an unsupported reducible map shape such as kmap, typeclass unification could delta-reduce map internals indefinitely before the certificate fast path failed. This prevented the existing simpl_map fallback from running.

## Testing

- make -j4
- focused raw-alias custom-instance, symbolic-module, and explicit insert-hit probes
- APCIAproof, APCACproof, and SchIAproof
- downstream Sum UA/NA and Ring Cell/Ctrl/Ring proof builds