### PR TITLE
sim: reduce SMod projections during function lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ release.
   `fnsem_lookup` hint database
 - keep recursive function-lookup certificate search inside its opaque hint
   database so unsupported module maps reach the `simpl_map` fallback
+- reduce `SMod` function-map projections during certificate lookup so
+  structured modules keep using the fast path
 - replace Helping's client-visible request state with a resource-only
   `HelpPend`/`HelpDone` protocol and make `HelpingOn.try_run` request-ID-only
 - add nested `IstHelp` transport and `helping_main_filtered` for client

--- a/theories/simulations/msim/FnsemLookup.v
+++ b/theories/simulations/msim/FnsemLookup.v
@@ -112,6 +112,7 @@ Global Hint Extern 30
       | gmap _ ?A =>
           let r := open_constr:(_ : option A) in
           notypeclasses refine
-            (@fnsem_lookup_result_to_mod _ _ _ _ _ _ _ _ sp m fn r _)
+            (@fnsem_lookup_result_to_mod _ _ _ _ _ _ _ _ sp m fn r _);
+          cbn [SMod.fnsems]
       end
   end : fnsem_lookup.


### PR DESCRIPTION
## Summary

- reduce `SMod.fnsems` immediately after certificate lookup crosses `SMod.to_mod`
- restore recursive certificate lookup through structured `SMod` compositions
- preserve the opaque `fnsem_lookup` search and `notypeclasses refine`, so unsupported shapes still reach the `simpl_map` fallback

## Motivation

`c0bcd04e` kept recursive certificate construction inside the opaque hint database to avoid reduction loops. Its `SMod.to_mod` builder left the recursive premise under an unreduced `SMod.fnsems` projection, so supported insert/add trees missed their hints and fell back to `simpl_map`.

Reducing that projection at this boundary exposes the structured map without reopening global typeclass reduction.

## Testing

- full CRIS build: `CODEX_COQ_MEMORY_MAX=4G make -f Makefile.coq -j2`
- SystemF regression build: `SumUAproof.vo`, `SumNAproof.vo`
- public CRIS-examples call-site provenance audit: 426 fallback events before this change, 18 after it
- downstream tamed Stack New/Push/Pop: 0/48 lookup conditions use the fallback after this change
- downstream tame memory and prophecy representatives: 0/44 lookup conditions use the fallback

Known remaining symbolic lookup fallbacks are tracked in #17.
