### PR TITLE
Refactoring `lsim`

### DIFF
--- a/theories/simulations/ctxrefine/ClosedAdequacy.v
+++ b/theories/simulations/ctxrefine/ClosedAdequacy.v
@@ -63,7 +63,8 @@ Section ADEQUACY.
              forall rt rs,
                ✓ rs ->
                (Own rs ⊢ Own rt ∗ IC ∗ winv (∅,∅)) ->
-               inhabited (LSim.lsim_mod (Mod.to_lmod Ms rs) (Mod.to_lmod Mt rt)))
+               ∃ lw, LSim.lsim_mod
+                 (Mod.to_lmod Ms rs) (Mod.to_lmod Mt rt) lw)
     : IC ⊢ refines Mt Ms.
   Proof.
     eapply gsim_closed_adequacy.
@@ -79,7 +80,7 @@ Section ADEQUACY.
   Proof.
     eapply lsim_closed_adequacy. intros WFT.
     split. { eapply ISim_wf; et. }
-    intros rt rs VALID SPLIT. econs.
+    intros rt rs VALID SPLIT. eexists.
     eapply ISim_adequacy; et.
     rewrite SPLIT; et.
   Qed.

--- a/theories/simulations/ctxrefine/ClosedAdequacy.v
+++ b/theories/simulations/ctxrefine/ClosedAdequacy.v
@@ -63,7 +63,7 @@ Section ADEQUACY.
              forall rt rs,
                ✓ rs ->
                (Own rs ⊢ Own rt ∗ IC ∗ winv (∅,∅)) ->
-               ∃ lw, LSim.lsim_mod
+               ∃ lw, LSim.lsim_lmod
                  (Mod.to_lmod Ms rs) (Mod.to_lmod Mt rt) lw)
     : IC ⊢ refines Mt Ms.
   Proof.

--- a/theories/simulations/lsim/LSim.v
+++ b/theories/simulations/lsim/LSim.v
@@ -514,7 +514,7 @@ Section LSim.
   Let st_src := ms_src.(LMod.initial_st).
   Let st_tgt := ms_tgt.(LMod.initial_st).
 
-  Inductive lsim_mod (lworld : LWorld) : Prop := mk {
+  Inductive lsim_lmod (lworld : LWorld) : Prop := mk {
     wf_winit :
       ∀ w st_src st_tgt
         (WF : lworld.(wf) w (st_src, st_tgt)),
@@ -532,7 +532,7 @@ Section LSim.
   }.
 
   Lemma wf_sim_miss lworld :
-    lsim_mod lworld →
+    lsim_lmod lworld →
     ∀ fn, fl_tgt !! fn = None → fl_src !! fn = None.
   Proof using.
     intros Hsim fn. destruct (fl_src !! fn) eqn: EQ; eauto.

--- a/theories/simulations/lsim/LSim.v
+++ b/theories/simulations/lsim/LSim.v
@@ -4,11 +4,22 @@ From CRIS.modules Require Export LMod.
   events like call, yield, etc. lsim is further abstracted to msim, and so on. You
   would not like to delve into the definitions unless for changing the metatheory *)
 (* wsim → isim → msim → lsim → gsim *)
-Section LSIM.
-  Context (fl_src fl_tgt : gmap fname (Any.t → itree lmodE Any.t)).
-  Context {world : Type} (winit : world) (wf : list world → lstateT * lstateT → Prop).
-  Context (wle : relation world) (le_refl : Reflexive wle) (le_trans : Transitive wle).
+
+Record LWorld : Type := mk_LWorld {
+  world :> Type;
+  winit : world;
+  wf : list world → lstateT * lstateT → Prop;
+  wle : relation world;
+  wle_refl : Reflexive wle;
+  wle_trans : Transitive wle;
+}.
+
+Section LORDER.
+  Context (lw : LWorld).
   Context (my_tid : nat).
+
+  Local Notation world := (world lw).
+  Local Notation wle := (wle lw).
 
   Definition le_mine (w w' : list world) : Prop :=
     List.length w <= List.length w' ∧
@@ -17,6 +28,65 @@ Section LSIM.
   Definition le_others (w w' : list world) : Prop :=
     List.length w = List.length w' ∧
     ∀ i, i ≠ my_tid → w !! i = w' !! i.
+
+  Lemma le_mine_refl : Reflexive le_mine.
+  Proof using lw.
+    intros x. split; first done.
+    intros wi Hwi. exists wi. split; first done.
+    apply wle_refl.
+  Qed.
+
+  Lemma le_mine_trans : Transitive le_mine.
+  Proof using lw.
+    intros x y z Hxy Hyz; destruct Hxy as [Hxy1 Hxy2], Hyz as [Hyz1 Hyz2]; split; try nia.
+    intros wi Hx.
+    eapply Hxy2 in Hx as [wi' [Hy LE1]].
+    eapply Hyz2 in Hy as [wi'' [Hz LE2]].
+    exists wi''. split; first done.
+    eapply wle_trans; et.
+  Qed.
+
+  Lemma le_others_refl : Reflexive le_others.
+  Proof using. rr. esplits; eauto. Qed.
+
+  Lemma le_others_trans : Transitive le_others.
+  Proof using.
+    rr. unfold le_others. i; des. split; i.
+    - etrans; eauto.
+    - etrans; try apply H2; eauto.
+  Qed.
+
+  Lemma le_others_inc w1 w2 x :
+    le_others w1 w2 → le_others (w1++[x]) (w2++[x]).
+  Proof using.
+    i. rdes H. split.
+    - rewrite !length_app. nia.
+    - i. assert (i < List.length w1 \/ i >= List.length w1) by nia; des.
+      + rewrite !lookup_app_l; try nia. eauto.
+      + rewrite !lookup_app_r; try nia. f_equal. nia.
+  Qed.
+End LORDER.
+
+Section LSIM.
+  Context (fl_src fl_tgt : gmap fname (Any.t → itree lmodE Any.t)).
+  Context (lw : LWorld).
+  Context (my_tid : nat).
+
+  Local Notation world := (world lw).
+  Local Notation winit := (winit lw).
+  Local Notation wf := (wf lw).
+  Local Notation le_mine := (le_mine lw my_tid).
+  Local Notation le_others := (le_others lw my_tid).
+
+  Local Lemma le_others_refl_lsim : Reflexive le_others.
+  Proof. exact (le_others_refl lw my_tid). Qed.
+
+  Local Lemma le_others_trans_lsim : Transitive le_others.
+  Proof. exact (le_others_trans lw my_tid). Qed.
+
+  Local Lemma le_others_inc_lsim w1 w2 x :
+    le_others w1 w2 → le_others (w1 ++ [x]) (w2 ++ [x]).
+  Proof. exact (le_others_inc lw my_tid w1 w2 x). Qed.
 
   Variant lsim_def
     (lsim : ∀ R_src R_tgt (RR : list world → lstateT → lstateT → R_src → R_tgt → Prop),
@@ -209,35 +279,6 @@ Section LSIM.
   Hint Resolve lsim_mon : paco.
   Hint Resolve cpn8_wcompat : paco.
 
-  Lemma le_mine_refl : Reflexive le_mine.
-  Proof using le_refl. ii. eexists; eauto. Qed.
-
-  Lemma le_mine_trans : Transitive le_mine.
-  Proof using le_trans.
-    intros x y z Hxy Hyz; destruct Hxy as [Hxy1 Hxy2], Hyz as [Hyz1 Hyz2]; split; try nia.
-    intros wi Hx; eapply Hxy2 in Hx as [wi' [Hy ?]]; eapply Hyz2 in Hy; des; eauto.
-  Qed.
-
-  Lemma le_others_refl : Reflexive le_others.
-  Proof using. rr. esplits; eauto. Qed.
-
-  Lemma le_others_trans : Transitive le_others.
-  Proof using.
-    rr. unfold le_others. i; des. split; i.
-    - etrans; eauto.
-    - etrans; try apply H2; eauto.
-  Qed.
-
-  Lemma le_others_inc w1 w2 x :
-    le_others w1 w2 → le_others (w1++[x]) (w2++[x]).
-  Proof using.
-    i. rdes H. split.
-    - rewrite !length_app. nia.
-    - i. assert (i < List.length w1 \/ i >= List.length w1) by nia; des.
-      + rewrite !lookup_app_l; try nia. eauto.
-      + rewrite !lookup_app_r; try nia. f_equal. nia.
-  Qed.
-
   Lemma lsim_wmon self R_src R_tgt RR w1 w2 ps pt src tgt
       (SIM : @_lsim self R_src R_tgt RR ps pt w2 src tgt)
       (WLE : le_others w1 w2) :
@@ -246,7 +287,8 @@ Section LSIM.
     move SIM before RR. revert_until SIM.
     pattern ps, pt, w2, src, tgt.
     eapply lsim_tarski, SIM.
-    i. econs. inv PR; eauto using lsim_def, le_others_refl, le_others_trans.
+    i. econs. inv PR;
+      eauto using lsim_def, le_others_refl_lsim, le_others_trans_lsim.
     econs. i; eapply K.
     destruct WLE. split.
     { rewrite !length_app. s. nia. }
@@ -325,7 +367,8 @@ Section LSIM.
         (SIM : gpaco8 _lsim (cpn8 _lsim) g g R0 R1 RR false false w st_src st_tgt) :
       gpaco8 _lsim (cpn8 _lsim) r g R0 R1 RR true true w st_src st_tgt.
   Proof using.
-    gstep. destruct st_src, st_tgt. econs; econs; eauto using le_others_refl.
+    gstep. destruct st_src, st_tgt. econs; econs;
+      eauto using le_others_refl_lsim.
   Qed.
 
   Lemma lsim_flag_mon lsim R_src R_tgt RR ps0 pt0 ps1 pt1 w st_src st_tgt
@@ -375,15 +418,18 @@ Section LSIM.
     pattern ps0, pt0, w0, x6, x7.
     eapply lsim_tarski, SIM.
     i. econs. inv PR;
-      eauto using lsim_def, lsim_wmon, le_others_refl, le_others_trans, le_others_inc.
+      eauto using lsim_def, lsim_wmon, le_others_refl_lsim,
+        le_others_trans_lsim, le_others_inc_lsim.
     exploit SRC; auto. exploit TGT; auto. i. clarify.
-    econs; cycle 1; eauto using rclo8, le_others_trans.
+    econs; cycle 1; eauto using rclo8, le_others_trans_lsim.
   Qed.
 
   Lemma lsim_flag_down R0 R1 RR r g w st_src st_tgt ps pt
       (SIM : gpaco8 _lsim (cpn8 _lsim) r g R0 R1 RR false false w st_src st_tgt) :
     gpaco8 _lsim (cpn8 _lsim) r g R0 R1 RR ps pt w st_src st_tgt.
-  Proof using. guclo lflagC_spec. econs; eauto using le_others_refl. Qed.
+  Proof using.
+    guclo lflagC_spec. econs; eauto using le_others_refl_lsim.
+  Qed.
 
   Lemma lsim_bot_flag_up w0 w st_src st_tgt ps pt
       (SIM : paco8 _lsim bot8 _ _ (final_rel wf w0) true true w st_src st_tgt) :
@@ -398,7 +444,8 @@ Section LSIM.
     all: try (by guclo lsim_indC_spec; hdes; econs; eauto).
     eapply lsim_flag_down. gfinal. right.
     eapply paco8_mon.
-    - punfold SIM0. pstep. eapply lsim_wmon; eauto using le_others_refl.
+    - punfold SIM0. pstep. eapply lsim_wmon;
+        eauto using le_others_refl_lsim.
     - ss.
   Qed.
 
@@ -467,33 +514,31 @@ Section LSim.
   Let st_src := ms_src.(LMod.initial_st).
   Let st_tgt := ms_tgt.(LMod.initial_st).
 
-  Inductive lsim_mod : Type := mk {
-    world : Type;
-    winit : world;
-    wf : list world → lstateT * lstateT → Prop;
-    wle : world → world → Prop;
-    wle_refl : Reflexive wle;
-    wle_trans : Transitive wle;
-    wf_winit : ∀ w st_src st_tgt (WF : wf w (st_src,st_tgt)), wf (w ++ [winit]) (st_src, st_tgt);
+  Inductive lsim_mod (lworld : LWorld) : Prop := mk {
+    wf_winit :
+      ∀ w st_src st_tgt
+        (WF : lworld.(wf) w (st_src, st_tgt)),
+        lworld.(wf) (w ++ [lworld.(winit)]) (st_src, st_tgt);
     sim_initial :
       ∀ it_src, fl_src !! entry = Some it_src →
         (∃ it_tgt, fl_tgt !! entry = Some it_tgt ∧
         ∀ arg, ∃ w0 w,
-          lsim fl_src fl_tgt winit wf wle 0 top2 [w0] false false [w]
+          lsim fl_src fl_tgt lworld 0 top2 [w0] false false [w]
             (st_src, it_src arg) (st_tgt, it_tgt arg));
     sim_fnsems:
       ∀ fn fs, fl_src !! funid fn = Some fs →
         ∃ ft, fl_tgt !! funid fn = Some ft ∧
-          ∀ my_tid, sim_fsem fl_src fl_tgt winit wf wle my_tid fs ft;
+          ∀ my_tid, sim_fsem fl_src fl_tgt lworld my_tid fs ft;
   }.
 
-  Lemma wf_sim_miss :
-    lsim_mod →
+  Lemma wf_sim_miss lworld :
+    lsim_mod lworld →
     ∀ fn, fl_tgt !! fn = None → fl_src !! fn = None.
   Proof using.
     intros Hsim fn. destruct (fl_src !! fn) eqn: EQ; eauto.
     destruct fn.
-    - apply Hsim in EQ as [ft [Hft Hftsim]]; rewrite Hft; ss.
-    - exploit (sim_initial Hsim); et; i; des; clarify.
+    - apply (sim_fnsems lworld Hsim) in EQ as [ft [Hft Hftsim]];
+        rewrite Hft; ss.
+    - exploit (sim_initial lworld Hsim); et; i; des; clarify.
   Qed.
 End LSim.

--- a/theories/simulations/lsim/LSimAdequacy.v
+++ b/theories/simulations/lsim/LSimAdequacy.v
@@ -1,5 +1,5 @@
 From CRIS.common Require Import Common.
-From CRIS.simulations.lsim Require Import LSim.
+From CRIS.simulations.lsim Require Import LSim LSimTactics.
 From CRIS.simulations.gsim Require Import GSim GSimTactics.
 
 Local Open Scope nat_scope.
@@ -9,7 +9,8 @@ Definition b2smj (b : bool) : smj := if b then smj_mid else smj_bot.
 
 Lemma lsim_gsim
     ms_src ms_tgt
-    (MSIM : lsim_mod ms_src ms_tgt)
+    (lw : LWorld)
+    (MSIM : lsim_mod ms_src ms_tgt lw)
     (* (WFS : LMod.wf ms_src) *)
     w ps pt my_tid itrs_src itrs_tgt st_src st_tgt
     (EQS : List.length w = List.length itrs_src)
@@ -20,15 +21,16 @@ Lemma lsim_gsim
       (INT : itrs_tgt !! tid = Some itr_tgt)
       (TID : tid < List.length w0)
       (FLG : if decide (tid = my_tid) then ps0 = ps ∧ pt0 = pt else ps0 = true ∧ pt0 = true)
-      (WLE : if decide (tid = my_tid) then w0 = w else le_mine (wle _ _ MSIM) tid w w0)
+      (WLE : if decide (tid = my_tid) then w0 = w
+             else le_mine lw tid w w0)
       (WF : if decide (tid = my_tid)
         then st_src0 = st_src ∧ st_tgt0 = st_tgt
-        else (wf _ _ MSIM) w0 (st_src0, st_tgt0)),
+        else wf lw w0 (st_src0, st_tgt0)),
       ∃ wany,
         lsim
           (LMod.fnsems ms_src) (LMod.fnsems ms_tgt)
-          (LSim.winit _ _ MSIM) (LSim.wf _ _ MSIM) (LSim.wle _ _ MSIM)
-          tid top2 wany ps0 pt0 w0 (st_src0, itr_src) (st_tgt0, itr_tgt)) :
+          lw tid top2 wany ps0 pt0 w0
+          (st_src0, itr_src) (st_tgt0, itr_tgt)) :
   gsim (λ '(st_src, ret_src) '(st_tgt, ret_tgt), ret_src = ret_tgt) (b2smj ps) (b2smj pt)
     (LModTr.interp_stateE Any.t
        (iterV (LModTr.handle_callE (LMod.prog ms_src)) (my_tid, itrs_src)) st_src)
@@ -57,7 +59,7 @@ Proof.
     unfold LMod.prog, unwrapU at 1. des_ifs; cycle 1.
     { unfold triggerUB, LModTr.pure_state. grind. do 2 zstep_s. }
     unfold LMod.prog, unwrapU at 1. des_ifs; cycle 1.
-    { unshelve eapply LSim.sim_fnsems in Heq; et. des.
+    { eapply (LSim.sim_fnsems _ _ lw MSIM) in Heq. des.
       erewrite Heq0 in Heq. ss.
     }
     grind. rename Heq into FIND.
@@ -70,17 +72,17 @@ Proof.
     { rewrite list_lookup_insert_ne in INS; try nia.
       rewrite list_lookup_insert_ne in INT; try nia.
       eapply SIM; eauto; des_ifs.
-      eapply le_mine_trans; [apply MSIM| |eauto].
+      eapply (le_mine_trans lw tid); [|eauto].
       rr in WLE. des. rr. split; try nia.
       intros wi Hwi; exists wi; rewrite -WLE1; ss.
-      esplits; eauto. apply MSIM.
+      esplits; eauto. apply (wle_refl lw).
     }
 
     rewrite !list_lookup_insert in INS; try nia. inv INS.
     rewrite !list_lookup_insert in INT; try nia. inv INT.
     esplits. ginit.
     guclo lbindC_spec. econs.
-    { eapply MSIM in FIND. des.
+    { eapply (LSim.sim_fnsems _ _ lw MSIM) in FIND. des.
       rewrite FIND in Heq0. inv Heq0.
       eapply lsim_flag_down. gfinal. right.
       eapply FIND0; eauto.
@@ -113,7 +115,7 @@ Proof.
     { do 2 f_equal. extensionalities. grind. }
     i. des_ifs; des; subst.
     + rewrite !list_lookup_insert in INS; try nia. inv INS.
-      eexists. ginit. guclo lflagC_spec. econs.
+      eexists. ginit. guclo_lflagC. econs.
       { gfinal. right.
         erewrite equal_f; eauto. do 3 f_equal. extensionalities. grind.
       }
@@ -132,7 +134,7 @@ Proof.
     { do 2 f_equal. extensionalities. grind. }
     i. des_ifs; des; subst.
     + rewrite !list_lookup_insert in INT; try nia. inv INT.
-      eexists. ginit. guclo lflagC_spec. econs.
+      eexists. ginit. guclo_lflagC. econs.
       { gfinal. right.
         erewrite f_equal; eauto. do 2 f_equal. extensionalities. grind.
       }
@@ -148,7 +150,7 @@ Proof.
       try rewrite list_lookup_insert; eauto; try nia.
     i. des_ifs; des; subst.
     + rewrite !list_lookup_insert in INS; try nia. inv INS.
-      eexists. ginit. guclo lflagC_spec. econs.
+      eexists. ginit. guclo_lflagC. econs.
       { gfinal. right. eapply K. }
       { apply le_others_refl. }
       { eauto. }
@@ -162,7 +164,7 @@ Proof.
       try rewrite list_lookup_insert; eauto; try nia.
     i. des_ifs; des; subst.
     + rewrite !list_lookup_insert in INT; try nia. inv INT.
-      eexists. ginit. guclo lflagC_spec. econs.
+      eexists. ginit. guclo_lflagC. econs.
       { gfinal. right. eapply K. }
       { apply le_others_refl. }
       { eauto. }
@@ -178,7 +180,7 @@ Proof.
       try rewrite list_lookup_insert; eauto; try nia.
     i. des_ifs; des; subst.
     + rewrite !list_lookup_insert in INS; try nia. inv INS.
-      eexists. ginit. guclo lflagC_spec. econs.
+      eexists. ginit. guclo_lflagC. econs.
       { gfinal. right. eapply K. }
       { apply le_others_refl. }
       { eauto. }
@@ -194,7 +196,7 @@ Proof.
       try rewrite list_lookup_insert; eauto; try nia.
     i. des_ifs; des; subst.
     + rewrite !list_lookup_insert in INT; try nia. inv INT.
-      eexists. ginit. guclo lflagC_spec. econs.
+      eexists. ginit. guclo_lflagC. econs.
       { gfinal. right. eapply K. }
       { apply le_others_refl. }
       { eauto. }
@@ -210,7 +212,7 @@ Proof.
       try rewrite list_lookup_insert; eauto; try nia.
     i. des_ifs; des; subst.
     + rewrite !list_lookup_insert in INS; try nia. inv INS.
-      eexists. ginit. guclo lflagC_spec. econs.
+      eexists. ginit. guclo_lflagC. econs.
       { gfinal. right. eapply K. }
       { apply le_others_refl. }
       { eauto. }
@@ -226,7 +228,7 @@ Proof.
       try rewrite list_lookup_insert; eauto; try nia.
     i. des_ifs; des; subst.
     + rewrite !list_lookup_insert in INT; try nia. inv INT.
-      eexists. ginit. guclo lflagC_spec. econs.
+      eexists. ginit. guclo_lflagC. econs.
       { gfinal. right. eapply K. }
       { apply le_others_refl. }
       { eauto. }
@@ -240,7 +242,7 @@ Proof.
       try rewrite list_lookup_insert; eauto; try nia.
     i. des_ifs; des; subst.
     + rewrite !list_lookup_insert in INS; try nia. inv INS.
-      eexists. ginit. guclo lflagC_spec. econs.
+      eexists. ginit. guclo_lflagC. econs.
       { gfinal. right. eapply K. }
       { apply le_others_refl. }
       { eauto. }
@@ -254,7 +256,7 @@ Proof.
       try rewrite list_lookup_insert; eauto; try nia.
     i. des_ifs; des; subst.
     + rewrite !list_lookup_insert in INT; try nia. inv INT.
-      eexists. ginit. guclo lflagC_spec. econs.
+      eexists. ginit. guclo_lflagC. econs.
       { gfinal. right. eapply K. }
       { apply le_others_refl. }
       { eauto. }
@@ -267,12 +269,14 @@ Proof.
     unfold LMod.prog, unwrapU at 1. des_ifs; cycle 1.
     { unfold triggerUB, LModTr.pure_state. grind. do 2 zstep_s. }
     unfold LMod.prog, unwrapU at 1. des_ifs; cycle 1.
-    { unshelve eapply LSim.sim_fnsems in Heq; et. des. erewrite Heq0 in Heq. ss. }
+    { eapply (LSim.sim_fnsems _ _ lw MSIM) in Heq.
+      des. erewrite Heq0 in Heq. ss. }
     grind. rename Heq into FIND.
 
     zstep_s. zstep_t. zprogress.
     gbase. eapply (CIH _ true true).
-    { instantiate (1:=x2++[LSim.winit _ _ MSIM]). rewrite !length_app !length_insert. eauto. }
+    { instantiate (1:=x2++[LSim.winit lw]).
+      rewrite !length_app !length_insert. eauto. }
     { rewrite !length_app /= !length_insert. nia. }
     { rewrite length_app. nia. }
     i. des_ifs; des; subst.
@@ -308,7 +312,8 @@ Proof.
       inv INT.
 
       esplits.
-      eapply MSIM in FIND. des. rewrite FIND in Heq0. inv Heq0.
+      eapply (LSim.sim_fnsems _ _ lw MSIM) in FIND.
+      des. rewrite FIND in Heq0. inv Heq0.
       ginit. eapply lsim_flag_down. gfinal. right.
       eapply lsim_mon_rr, FIND0; et.
 
@@ -331,7 +336,7 @@ Proof.
       - rewrite !list_lookup_insert in INS; try nia. inv INS.
         rewrite !list_lookup_insert in INT; try nia. inv INT.
         eexists. eapply K; eauto.
-        apply le_mine_refl. apply MSIM.
+        apply (le_mine_refl lw my_tid).
       - rewrite list_lookup_insert_ne in INS; try nia.
         rewrite list_lookup_insert_ne in INT; try nia.
         eapply SIM; eauto; des_ifs; eauto.
@@ -339,7 +344,7 @@ Proof.
         { inv WLE; try nia. }
         ii. esplits; eauto.
         { inv WLE; hexploit H1; eauto. intros <-; eauto. }
-        { apply LSim.wle_refl. }
+        { apply (LSim.wle_refl lw). }
     }
     { assert (DEC' : tid0 = my_tid \/ tid0 ≠ my_tid) by nia; des; subst.
       - rewrite !list_lookup_insert in INS; try nia. inv INS.
@@ -348,10 +353,10 @@ Proof.
       - rewrite list_lookup_insert_ne in INS; try nia.
         rewrite list_lookup_insert_ne in INT; try nia.
         eapply SIM; eauto; des_ifs; eauto.
-        eapply le_mine_trans; [apply MSIM| |eauto].
+        eapply (le_mine_trans lw tid0); [|eauto].
         destruct WLE. split; try nia.
         ii. rewrite <-H0. rewrite H1.
-        esplits; eauto. apply MSIM. eauto.
+        esplits; eauto. apply (wle_refl lw). eauto.
     }
 
   - rewrite !unfold_iterV. s. rewrite LKS LKT. grind.
@@ -383,7 +388,7 @@ Proof.
     i. des_ifs; cycle 1; des; subst.
     { eapply SIM; eauto; des_ifs; eauto. }
 
-    eexists. ginit. guclo lflagC_spec.
+    eexists. ginit. guclo_lflagC.
     econs; try eassumption; eauto with paco.
 
 Unshelve. all : try exact smj_top.
@@ -391,22 +396,24 @@ Qed.
 
 (* ADEQUACY *)
 Lemma lsim_adequacy
-  ms_src ms_tgt arg
-  (SIM : lsim_mod ms_src ms_tgt)
+  ms_src ms_tgt arg (lw : LWorld)
+  (SIM : lsim_mod ms_src ms_tgt lw)
   : gsim eq smj_bot smj_bot (LMod.compile ms_src arg) (LMod.compile ms_tgt arg).
 Proof.
   rewrite /LMod.compile /LModTr.trans /LModTr.interp_callE.
   ginit.
   destruct (_ !! _) eqn: E; s; cycle 1.
   { zstep_s. }
-  ired. hexploit (LSim.sim_initial _ _ SIM); et. i; des.
+  ired. hexploit (LSim.sim_initial _ _ lw SIM); et. i; des.
   rewrite H. s. ired. specialize (H0 arg). des.
   erewrite <-(bind_ret_r (ITree.map snd _)), (bind_map _ _ _).
   erewrite <-(bind_ret_r (ITree.map snd _)), (bind_map _ _ _).
 
   guclo bindC_spec. econs; i; s.
   { gfinal. right.
-    eapply lsim_gsim with (ps := false) (pt := false); cycle 3.
+    eapply (lsim_gsim _ _ lw SIM) with
+      (ps := false) (pt := false);
+      cycle 3.
     - i. destruct tid; ss; inv INS. des; subst. eexists.
       instantiate (1:= [_]). eauto.
     - et.

--- a/theories/simulations/lsim/LSimAdequacy.v
+++ b/theories/simulations/lsim/LSimAdequacy.v
@@ -10,7 +10,7 @@ Definition b2smj (b : bool) : smj := if b then smj_mid else smj_bot.
 Lemma lsim_gsim
     ms_src ms_tgt
     (lw : LWorld)
-    (MSIM : lsim_mod ms_src ms_tgt lw)
+    (MSIM : lsim_lmod ms_src ms_tgt lw)
     (* (WFS : LMod.wf ms_src) *)
     w ps pt my_tid itrs_src itrs_tgt st_src st_tgt
     (EQS : List.length w = List.length itrs_src)
@@ -397,7 +397,7 @@ Qed.
 (* ADEQUACY *)
 Lemma lsim_adequacy
   ms_src ms_tgt arg (lw : LWorld)
-  (SIM : lsim_mod ms_src ms_tgt lw)
+  (SIM : lsim_lmod ms_src ms_tgt lw)
   : gsim eq smj_bot smj_bot (LMod.compile ms_src arg) (LMod.compile ms_tgt arg).
 Proof.
   rewrite /LMod.compile /LModTr.trans /LModTr.interp_callE.

--- a/theories/simulations/lsim/LSimTactics.v
+++ b/theories/simulations/lsim/LSimTactics.v
@@ -13,9 +13,24 @@ Ltac ired_t := try (prw _red_gen 1 1 0).
 Ltac ired_both := ired_s; ired_t.
 
 Ltac prep := ired_both. (* prepare *)
-  
+
+Ltac apply_lsimC_spec :=
+  match goal with
+  | [ |- gpaco8 (_lsim ?fl_src ?fl_tgt ?lw ?my_tid)
+          _ _ _ _ _ _ _ _ _ _ _ ] =>
+    apply (lsimC_spec fl_src fl_tgt lw my_tid)
+  end.
+
+Ltac guclo_lflagC :=
+  match goal with
+  | [ |- gpaco8 (_lsim ?fl_src ?fl_tgt ?lw ?my_tid)
+          _ _ _ _ _ _ _ _ _ _ _ ] =>
+    guclo (lflagC_spec fl_src fl_tgt lw my_tid);
+      try exact (lsim_mon fl_src fl_tgt lw my_tid)
+  end.
+
 Ltac _step :=
-  ired_both; apply lsimC_spec; econs; i;
+  ired_both; apply_lsimC_spec; econs; i;
   match goal with
   | [ |- exists (_ : unit), _ ] => esplits; [eauto|..]; i
   | [ |- exists _, _ ] => fail 1

--- a/theories/simulations/lsim/LSimTactics.v
+++ b/theories/simulations/lsim/LSimTactics.v
@@ -7,124 +7,23 @@ Set Implicit Arguments.
 #[export] Hint Resolve lsim_mon : paco.
 #[export] Hint Resolve cpn8_wcompat : paco.
 
-
-
 Ltac ired_s := try (prw _red_gen 2 1 0).
 Ltac ired_t := try (prw _red_gen 1 1 0).
 
 Ltac ired_both := ired_s; ired_t.
 
-Ltac prep := ired_both.
+Ltac prep := ired_both. (* prepare *)
   
-Ltac _force_s :=
-  prep;
-  match goal with
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, unwrapN ?ox >>= _) (_, _)) ] =>
-    let tvar := fresh "tmp" in
-    let thyp := fresh "TMP" in
-    remember (unwrapN ox) as tvar eqn:thyp; unfold unwrapN in thyp; subst tvar;
-    let name := fresh "_UNWRAPN" in
-    destruct (ox) eqn:name; [|exfalso]; cycle 1
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, guarantee ?P >>= _) (_, _)) ] =>
-    let tvar := fresh "tmp" in
-    let thyp := fresh "TMP" in
-    remember (guarantee P) as tvar eqn:thyp; unfold guarantee in thyp; subst tvar;
-    let name := fresh "_GUARANTEE" in
-    destruct (classic P) as [name|name]; [ired_both; apply lsimC_spec; eapply lsim_choose_src; [exists name]|contradict name]; cycle 1
-
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, ITree.bind (interp _ guarantee ?P) _ (_, _))) ] =>
-    let tvar := fresh "tmp" in
-    let thyp := fresh "TMP" in
-    remember (guarantee P) as tvar eqn:thyp; unfold guarantee in thyp; subst tvar;
-    let name := fresh "_GUARANTEE" in
-    destruct (classic P) as [name|name]; [ired_both; apply lsimC_spec; eapply lsim_choose_src; [exists name]|contradict name]; cycle 1
-
-   (* TODO : handle interp_hCallE_tgt better and remove this case *)
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, ITree.bind (interp _ (guarantee ?P )) _) (_, _)) ] =>
-    let tvar := fresh "tmp" in
-    let thyp := fresh "TMP" in
-    remember (guarantee P) as tvar eqn:thyp; unfold guarantee in thyp; subst tvar;
-    let name := fresh "_GUARANTEE" in
-    destruct (classic P) as [name|name]; [ired_both; apply lsimC_spec; eapply lsim_choose_src; [exists name]|contradict name]; cycle 1; clear name
-
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, ?i_src) (_, ?i_tgt)) ] =>
-    seal i_tgt; apply lsimC_spec; econs; unseal i_tgt
-  end
-.
-
-Ltac _force_t :=
-  prep;
-  match goal with
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, _) (_, unwrapU ?ox >>= _)) ] =>
-    let tvar := fresh "tmp" in
-    let thyp := fresh "TMP" in
-    remember (unwrapU ox) as tvar eqn:thyp; unfold unwrapU in thyp; subst tvar;
-    let name := fresh "_UNWRAPU" in
-    destruct (ox) eqn:name; [|exfalso]; cycle 1
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, _) (_, assume ?P >>= _)) ] =>
-    let tvar := fresh "tmp" in
-    let thyp := fresh "TMP" in
-    remember (assume P) as tvar eqn:thyp; unfold assume in thyp; subst tvar;
-    let name := fresh "_ASSUME" in
-    destruct (classic P) as [name|name]; [ired_both; apply lsimC_spec; eapply lsim_take_tgt; [exists name]|contradict name]; cycle 1
-
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, ?i_src) (_, ?i_tgt)) ] =>
-    seal i_src; apply lsimC_spec; econs; unseal i_src
-  end
-.
-
 Ltac _step :=
-  match goal with
-  (*** blacklisting ***)
-  (* | [ |- (gpaco5 (_lsim wf) _ _ _ _ (_, trigger (Choose _) >>= _) (_, ?i_tgt)) ] => idtac *)
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, triggerUB >>= _) (_, _)) ] =>
-    unfold triggerUB; ired_s; _step; done
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, unwrapU ?ox >>= _) (_, _)) ] =>
-    let tvar := fresh "tmp" in
-    let thyp := fresh "TMP" in
-    remember (unwrapU ox) as tvar eqn:thyp; unfold unwrapU in thyp; subst tvar;
-    let name := fresh "_UNWRAPU" in
-    destruct (ox) eqn:name; [|unfold triggerUB; ired_both; _force_s; ss; fail]
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, assume ?P >>= _) (_, _)) ] =>
-    let tvar := fresh "tmp" in
-    let thyp := fresh "TMP" in
-    remember (assume P) as tvar eqn:thyp; unfold assume in thyp; subst tvar;
-    let name := fresh "_ASSUME" in
-    ired_both; apply lsimC_spec; eapply lsim_take_src; intro name
-
-  (*** blacklisting ***)
-  (* | [ |- (gpaco5 (_lsim wf) _ _ _ _ (_, _) (_, trigger (Take _) >>= _)) ] => idtac *)
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, triggerNB >>= _) (_, _)) ] =>
-    unfold triggerNB; ired_t; _step; done
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, _) (_, unwrapN ?ox >>= _)) ] =>
-    let tvar := fresh "tmp" in
-    let thyp := fresh "TMP" in
-    remember (unwrapN ox) as tvar eqn:thyp; unfold unwrapN in thyp; subst tvar;
-    let name := fresh "_UNWRAPN" in
-    destruct (ox) eqn:name; [|unfold triggerNB; ired_both; _force_t; ss; fail]
-  | [ |- (gpaco9 (_lsim _ _ _ _ _ _) _ _ _ _ _ _ _ _ _ _ (_, _) (_, guarantee ?P >>= _)) ] =>
-    let tvar := fresh "tmp" in
-    let thyp := fresh "TMP" in
-    remember (guarantee P) as tvar eqn:thyp; unfold guarantee in thyp; subst tvar;
-    let name := fresh "_GUARANTEE" in
-    ired_both; apply lsimC_spec; eapply lsim_choose_tgt; intro name
- 
-  | _ => (*** default ***)
-    ired_both; apply lsimC_spec; econs; i
-    (* eapply safe_sim_sim; econs; i *)
-  end;
+  ired_both; apply lsimC_spec; econs; i;
   match goal with
   | [ |- exists (_ : unit), _ ] => esplits; [eauto|..]; i
   | [ |- exists _, _ ] => fail 1
   | _ => idtac
-  end
-.
+  end.
 
-Ltac steps := (hrepeat do 1 (*** pre processing ***) prep; _step; (*** post processing ***) simpl; des_ifs_safe); prep.
-Ltac step := ((*** pre processing ***) prep; _step; (*** post processing ***) simpl; des_ifs_safe).
-
-Ltac force_s := _force_s.
-Ltac force_t := _force_t.
+Ltac step := prep; _step; simpl; des_ifs_safe.
+Ltac steps := (hrepeat ltac:(step)); prep.
 
 Tactic Notation "hide" constr(tm) integer(occ) :=
   let tmp := fresh "tmp" in let TMP := fresh "TMP" in
@@ -132,22 +31,3 @@ Tactic Notation "hide" constr(tm) integer(occ) :=
   unfold xxx in *; clear xxx; guardH TMP.
 Ltac unhide :=
   unguard; subst.
-
-Notation "'☏--' wf '--' n '------------------------------------------------------------------' src0 tgt0 '------------------------------------------------------------------' src1 '------------------------------------------------------------------' src2 tgt2"
-  :=
-    (gpaco9 (_lsim _ _ wf _ _ _) _ _ _ _ _ _ _ _ _ n ((Any.pair src0 src1), src2) (tgt0, tgt2))
-      (at level 100, only printing,
-       format "'☏--' wf '--' n '//' '------------------------------------------------------------------' '//' src0 '//' tgt0 '//' '------------------------------------------------------------------' '//' src1 '//' '------------------------------------------------------------------' '//' src2 '//' '//' '//' tgt2 '//' ").
-
-Notation "'☏--' wf '--' n '------------------------------------------------------------------' src0 tgt0 '------------------------------------------------------------------' src1 tgt1 '------------------------------------------------------------------' src2 tgt2"
-  :=
-    (gpaco9 (_lsim _ _ wf _ _ _) _ _ _ _ _ _ _ _ _ n ((Any.pair src0 src1), src2) ((Any.pair tgt0 tgt1), tgt2))
-      (at level 100, only printing,
-       format "'☏--' wf '--' n '//' '------------------------------------------------------------------' '//' src0 '//' tgt0 '//' '------------------------------------------------------------------' '//' src1 '//' tgt1 '//' '------------------------------------------------------------------' '//' src2 '//' '//' '//' tgt2 '//' ").
-
-Notation "'☏--' wf '--' n '------------------------------------------------------------------' src0 tgt0 '------------------------------------------------------------------' '------------------------------------------------------------------' src2 tgt2"
-  :=
-    (gpaco9 (_lsim _ _ wf _ _ _) _ _ _ _ _ _ _ _ _ n (src0, src2) (tgt0, tgt2))
-      (at level 100, only printing,
-       format "'☏--' wf '--' n '//' '------------------------------------------------------------------' '//' src0 '//' tgt0 '//' '------------------------------------------------------------------' '//' '//' '------------------------------------------------------------------' '//' src2 '//' '//' '//' tgt2 '//' ").
-

--- a/theories/simulations/msim/ISimAdequacy.v
+++ b/theories/simulations/msim/ISimAdequacy.v
@@ -36,16 +36,14 @@ Section ISIM_ADEQUACY.
       (WF : ✓ rs)
       (WFT : Mod.wf mt)
       (SIM : ISim.t closed ms mt IC Ist) :
-    lsim_mod (Mod.to_lmod ms rs) (Mod.to_lmod mt rt).
+    lsim_mod
+      (Mod.to_lmod ms rs) (Mod.to_lmod mt rt)
+      (IstWorld (λ x y, winv (∅, ∅) ∗ Ist x y)%I).
   Proof using.
     hexploit ISim_wf; eauto; intros WFS.
     dup SIM. dup WFS. dup WFT. destruct SIM0, WFS0, WFT0.
-    econs; ss.
-    - ii; subst; eauto.
-    - instantiate (1 := Σ).
-      instantiate (2 := interp_inv (λ x y, winv (∅, ∅) ∗ Ist x y)%I).
-      instantiate (1 := ε).
-      ii; inv WF0. econs; eauto.
+    constructor; ss.
+    - ii; inv WF0. econs; eauto.
       iIntros "H". iMod (MRS with "H") as "H". iModIntro.
       unfold ctx_sem. rewrite big_opL_app. s. rewrite ?right_id; eauto.
     - intros it_src Hsrc; rewrite ?lookup_fmap lookup_omap in Hsrc.
@@ -75,7 +73,7 @@ Section ISIM_ADEQUACY.
       + eapply map_Forall_fmap, map_Forall_impl; eauto; intros ? [[??]|]; ss; intros H; inv H.
       + destruct ms; ss; apply nodup_init; eauto.
       + destruct mt; ss; apply nodup_init; eauto.
-      + eapply le_mine_refl. et.
+      + eapply le_mine_refl.
       + ginit. eapply isim_init.
         * iIntros "P". iApply isim_mono; cycle 1; i.
           { iApply isim_ist_frame; et. }
@@ -97,7 +95,7 @@ Section ISIM_ADEQUACY.
       eexists; split; first done.
       intros tid ??? arg ??. inv SIMMRS. specialize (Hsim arg st_src st_tgt).
       eapply msim_adequacy; eauto; cycle 4.
-      { apply le_mine_refl. ii; eauto. }
+      { apply le_mine_refl. }
       { ginit; cycle 2; i.
         eapply gpaco8_mon with (r := bot8) (rg:= iunlift ibot); eauto using iunlift_ibot.
         eapply isim_init; eauto.

--- a/theories/simulations/msim/ISimAdequacy.v
+++ b/theories/simulations/msim/ISimAdequacy.v
@@ -30,13 +30,13 @@ Section ISIM_ADEQUACY.
     - eapply Hwfsrc in Hin. rr in Hin. des; ss.
   Qed.
 
-  (* ISim.t implies lsim_mod *)
+  (* ISim.t implies lsim_lmod *)
   Lemma ISim_adequacy (ms mt : Mod.t) (rs rt : Σ) (IC : iProp Σ) Ist
       (SUB : Own rs ⊢ |==> Own rt ∗ (IC ∗ winv (∅,∅)))
       (WF : ✓ rs)
       (WFT : Mod.wf mt)
       (SIM : ISim.t closed ms mt IC Ist) :
-    lsim_mod
+    lsim_lmod
       (Mod.to_lmod ms rs) (Mod.to_lmod mt rt)
       (IstWorld (λ x y, winv (∅, ∅) ∗ Ist x y)%I).
   Proof using.

--- a/theories/simulations/msim/MSimAdequacy.v
+++ b/theories/simulations/msim/MSimAdequacy.v
@@ -17,6 +17,29 @@ Local Hint Resolve own_upd_in_middle : core.
 Definition ctx_sem `{Σ: GRA} (ctx : list Σ) : Σ :=
   [^(⋅) list] r ∈ ctx, r.
 
+Variant interp_inv `{Σ : GRA} (Ist : ist_type Σ) :
+    list Σ → lstateT * lstateT → Prop :=
+| interp_inv_intro
+    (ctx : list Σ) (mr_src mr_tgt : Σ) st_src st_tgt mr
+    (WF : ✓ mr_src)
+    (MRS : Own mr_src ⊢ |==> Own (ctx_sem ctx ⋅ mr ⋅ mr_tgt))
+    (MR : Own mr ⊢ |==> Ist st_src st_tgt)
+    (NODUPS : map_Forall (const is_Some) st_src)
+    (NODUPT : map_Forall (const is_Some) st_tgt)
+    :
+  interp_inv Ist ctx
+    ((st_src, mr_src↑), (st_tgt, mr_tgt↑)).
+
+Definition IstWorld `{Σ : GRA} (Ist : ist_type Σ) : LWorld :=
+  {|
+    world := Σ;
+    winit := ε;
+    wf := interp_inv Ist;
+    wle := eq;
+    wle_refl := λ _, eq_refl;
+    wle_trans := λ x y z, @eq_trans Σ x y z
+  |}.
+
 Definition ctx_set `{Σ: GRA} (my_tid : nat) (ctx : list Σ) (r : Σ) : list Σ :=
   <[my_tid := r]> ctx.
 
@@ -42,8 +65,9 @@ Proof.
   { by rewrite /ctx_add; rewrite emy; ss; rewrite ctx_set_sem //= /ctx_set list_insert_id; ss. }
 Qed.
 
-Lemma le_mine_in `{Σ: GRA} (my_tid : nat) (ctx0 ctx : list Σ)
-    (CTXLE : le_mine eq my_tid ctx0 ctx)
+Lemma le_mine_in `{Σ: GRA} {Ist : ist_type Σ}
+    (my_tid : nat) (ctx0 ctx : list Σ)
+    (CTXLE : le_mine (IstWorld Ist) my_tid ctx0 ctx)
     (IN : my_tid < List.length ctx0) :
   my_tid < List.length ctx.
 Proof.
@@ -53,17 +77,19 @@ Proof.
   eapply lookup_lt_is_Some_1. eauto.
 Qed.
 
-Lemma ctx_set_le_others `{Σ: GRA} (my_tid : nat) ctx r :
-  le_others my_tid ctx (ctx_set my_tid ctx r).
+Lemma ctx_set_le_others `{Σ: GRA} {Ist : ist_type Σ}
+    (my_tid : nat) ctx r :
+  le_others (IstWorld Ist) my_tid ctx (ctx_set my_tid ctx r).
 Proof.
   unfold ctx_set. r; esplits.
   - rewrite length_insert. eauto.
   - i. rewrite list_lookup_insert_ne; eauto.
 Qed.
 
-Lemma ctx_le_mine_sem `{Σ: GRA} (my_tid : nat) (w0 w1 : list Σ)
+Lemma ctx_le_mine_sem `{Σ: GRA} {Ist : ist_type Σ}
+    (my_tid : nat) (w0 w1 : list Σ)
     (IN : my_tid < List.length w0)
-    (LE : le_mine eq my_tid w0 w1) :
+    (LE : le_mine (IstWorld Ist) my_tid w0 w1) :
   ctx_sem w1 = ctx_sem (ctx_set my_tid w1 (or_else (w0 !! my_tid) ε)).
 Proof.
   unfold ctx_sem, ctx_set.
@@ -73,21 +99,12 @@ Proof.
   destruct LE.
   destruct my_tid; ss.
   - exploit H0; ss. i; des. inv x0. eauto.
-  - erewrite IHw1; eauto; try nia.
-    split; et. nia.
+  - erewrite (IHw1 Ist my_tid w0); eauto; try nia.
+    unfold le_mine; simpl.
+    split; first nia.
+    intros wi Hwi. eapply H0 in Hwi as [wi' [Hwi ->]].
+    exists wi'. split; done.
 Qed.
-
-Variant interp_inv `{Σ : GRA} (Ist : ist_type Σ) : list Σ → lstateT * lstateT → Prop :=
-| interp_inv_intro
-    (ctx : list Σ) (mr_src mr_tgt : Σ) st_src st_tgt mr
-    (WF : ✓ mr_src)
-    (MRS : Own mr_src ⊢ |==> Own (ctx_sem ctx ⋅ mr ⋅ mr_tgt))
-    (MR : Own mr ⊢ |==> Ist st_src st_tgt)
-    (NODUPS : map_Forall (const is_Some) st_src)
-    (NODUPT : map_Forall (const is_Some) st_tgt)
-    :
-  interp_inv Ist ctx
-    ((st_src, mr_src↑), (st_tgt, mr_tgt↑)).
 
 (* Adequacy requires 'contextual = closed'*)
 Lemma msim_adequacy
@@ -106,12 +123,12 @@ Lemma msim_adequacy
     (NODUPFT : map_Forall (const is_Some) fl_tgt)
     (NODUPS : map_Forall (const is_Some) st_src)
     (NODUPT : map_Forall (const is_Some) st_tgt)
-    (CTXLE : @le_mine Σ eq my_tid ctx0 ctx)
+    (CTXLE : le_mine (IstWorld Ist) my_tid ctx0 ctx)
     (TID : my_tid < List.length ctx0)
     (SIM : msim closed fl_src fl_tgt Ist (ist_with_eq RR) ps pt (st_src, itr_src) (st_tgt, itr_tgt) fmr)
     (WF : ✓ mr_src)
     (FMR : Own mr_src ⊢ |==> Own ((ctx_sem ctx) ⋅ fmr ⋅ mr_tgt)) :
-  lsim fl_src0 fl_tgt0 ε (interp_inv Ist) eq my_tid
+  lsim fl_src0 fl_tgt0 (IstWorld Ist) my_tid
     (interp_inv RR) ctx0 ps pt ctx
     ((st_src, mr_src ↑), ModTr.trans itr_src)
     ((st_tgt, mr_tgt ↑), ModTr.trans itr_tgt).
@@ -145,7 +162,8 @@ Proof.
 
   - clarify; ired.
     hexploit (Own_bupd_split fmr0); eauto; intros [ist [frame [UPD [Hist Hframe]]]].
-    guclo lflagC_spec; econs; try instantiate (1:=ctx_add my_tid ctx frame); eauto using ctx_set_le_others.
+    guclo_lflagC; econs; try instantiate (1:=ctx_add my_tid ctx frame);
+      eauto using ctx_set_le_others.
     step.
     { econs; eauto.
       { iIntros "H"; iMod (FMR with "H") as "[[CTX FMR] MRT]"; iMod (x1 with "FMR") as "FMR".
@@ -156,17 +174,19 @@ Proof.
       iIntros "H"; iModIntro; iApply Hist; done.
     }
     ired. inv WF0.
-    guclo lflagC_spec; econs; try instantiate (1:=ctx_set w1 (or_else (ctx !! my_tid) ε));
+    guclo_lflagC; econs; try instantiate (1:=ctx_set w1 (or_else (ctx !! my_tid) ε));
       eauto using ctx_set_le_others.
     eapply (K _ st_src1 st_tgt1) with (fmr0:=(frame ⋅ mr)); eauto; try nia.
     { iIntros "[F M]"; iMod (MR with "M") as "M"; iSplitL "M"; iModIntro; eauto. iApply Hframe; done. }
     { instantiate (1:= default ε (ctx !! my_tid)).
-      eapply le_mine_trans; first by ii; subst.
+      eapply (le_mine_trans (IstWorld Ist) my_tid).
       { apply CTXLE. }
       { split.
         { destruct WLE. unfold ctx_add, ctx_set in *.
           rewrite !length_insert in H |- *. nia. }
-        intros ? ->; ss; rewrite /ctx_set list_lookup_insert; eauto.
+        intros ? Hlookup.
+        rewrite Hlookup /=.
+        rewrite /ctx_set list_lookup_insert; eauto.
         eapply le_mine_in; eauto; rewrite /ctx_add /ctx_set length_insert; eauto using le_mine_in.
       }
     }
@@ -324,7 +344,7 @@ Proof.
     }
 
   - clarify. step. ired. eapply K; eauto.
-    { eapply le_mine_trans; eauto; first ii; subst; ss.
+    { eapply (le_mine_trans (IstWorld Ist) my_tid); eauto; ss.
       split.
       { rewrite length_app. s. nia. }
       ii; esplits; ss; rewrite lookup_app_l; eauto using le_mine_in.
@@ -336,7 +356,7 @@ Proof.
 
   - clarify.
     hexploit (Own_bupd_split fmr0); eauto; intros [ist [frame [UPD [Hist Hframe]]]].
-    guclo lflagC_spec; econs; try instantiate (1:=ctx_add my_tid ctx frame); eauto using ctx_set_le_others.
+    guclo_lflagC; econs; try instantiate (1:=ctx_add my_tid ctx frame); eauto using ctx_set_le_others.
     step.
     { econs; eauto.
       { iIntros "H"; iMod (FMR with "H") as "[[CTX FMR] MRT]"; iMod (x1 with "FMR") as "FMR".
@@ -347,17 +367,19 @@ Proof.
       iIntros "H"; iModIntro; iApply Hist; done.
     }
     ired. inv WF0.
-    guclo lflagC_spec; econs; try instantiate (1:=ctx_set w1 (default ε (ctx !! my_tid)));
+    guclo_lflagC; econs; try instantiate (1:=ctx_set w1 (default ε (ctx !! my_tid)));
       eauto using ctx_set_le_others.
     eapply (K st_src1 st_tgt1) with (fmr0:=(frame ⋅ mr)); eauto; try nia.
     { iIntros "[F M]"; iMod (MR with "M") as "M"; iSplitL "M"; iModIntro; eauto. iApply Hframe; done. }
-    { eapply le_mine_trans; first by ii; subst.
+    { eapply (le_mine_trans (IstWorld Ist) my_tid).
       { apply CTXLE. }
       { instantiate (1:= default ε (ctx !! my_tid)).
         split.
         { destruct WLE. unfold ctx_add, ctx_set in *.
           rewrite !length_insert in H |- *. nia. }
-        intros ? ->; ss; rewrite /ctx_set list_lookup_insert; eauto.
+        intros ? Hlookup.
+        rewrite Hlookup /=.
+        rewrite /ctx_set list_lookup_insert; eauto.
         eapply le_mine_in; eauto; rewrite /ctx_add /ctx_set length_insert; eauto using le_mine_in.
       }
     }


### PR DESCRIPTION
* Remove legacy tactics and notations for `lsim`. They were mostly dead code.
* Add a record type `LWorld` that combines `world`, `winit`, `wf`, ...
* `lsim_mod` takes new parameter `W : LWorld`, and it is now a predicate rather than a type family.
* Rename: `lsim_mod` -> `lsim_lmod`