### PR TITLE
build: check dependencies for single-file targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ release.
 
 ## Unreleased
 
+- check imported dependencies on every single-file `.vo` and `.vos` build
+
 - make `cStartFunSim` validate reduced function-lookup certificates before
   committing to its fast path, preserving the `simpl_map` fallback
 - `key` type is now defined as a variant type.

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,20 @@ coq_dir_vosfiles = $(patsubst %.v,%.vos,$(call coq_dir_vfiles,$(1)))
 
 .PHONY: all all-quick $(COQDIRS) $(COQDIRS_QUICK)
 
-%.vo: %.v
+%.vo: %.v Makefile.coq FORCE
 	$(MAKE) -f Makefile.coq $@
 
-%.vos: %.v
+%.vos: %.v Makefile.coq FORCE
 	$(MAKE) -f Makefile.coq $@
 
 all: Makefile.coq $(COQTHEORIES)
 	$(MAKE) -f Makefile.coq $(patsubst %.v,%.vo,$(COQTHEORIES))
 all-quick: Makefile.coq $(COQTHEORIES)
 	$(MAKE) -f Makefile.coq $(patsubst %.v,%.vos,$(COQTHEORIES))
+
+# Always let the generated makefile check imported dependencies.
+.PHONY: FORCE
+FORCE:
 
 $(COQDIRS): Makefile.coq
 	$(MAKE) -f Makefile.coq $(call coq_dir_vofiles,$@)


### PR DESCRIPTION
Single-file `.vo` and `.vos` requests could report “up to date” without checking imported dependencies, because the top-level rule only compared the target with its own source. Add a phony prerequisite so every request invokes the generated Makefile, and ensure that Makefile is current first. The generated rules still skip compilation when all dependencies are current; the default target remains `all`.

Validation: isolated Make regression checks passed for both `.vo` and `.vos`, covering unchanged files, a newer imported artifact, changed dependency source, and repeated incremental builds. The real `itreeS/Basics.vo` target compiled using the configured Rocq wrapper and switch. The full public `make -j1 all` build passed with Rocq 9.0.0, Iris 4.4.0, and stdpp 1.12.0 through the configured cgroup wrapper.
